### PR TITLE
docs: documenting about the code-oss ban on vscode extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 # Clone this repository into the extensions folder of VSCode
 $ git clone https://github.com/QuixoticCS/quixotic-vscode ~/.vscode/extensions/quixotic-vscode
-# Note: if using VScodium, clone into ~/.vscode-oss/extensions/quixotic-vscode instead
+# Note: if using VScodium, clone into ~/.vscode-oss/extensions/quixotic instead (folder named quixotic-vscode may not work on some versions)
 ```
 
 ## Applying


### PR DESCRIPTION
I recently discovered all extensions with the "vscode" name in it were ignored on newer code-oss versions.
This had me searching for a while... I propose to update the doc to tell code-oss users about it.